### PR TITLE
Updates to allow for a remote docker repo such as Dockerhub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ TOKEN=your token
 PREFIX=ff!
 INVITE=botinvite
 
+# Uncomment if you want to use your own dockerhub repo & docker-compose push
+#DOCKER_REGISTRY_URL=yourregistry/form-fox:latest
+
 # for creating forms/responses/etc
 CHARS=abcdefghijklmnopqrstuvwxyz1234567890
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:latest
-WORKDIR /app/
-COPY package.json .
-RUN npm install
-COPY . .
+WORKDIR /app
+COPY package.json ./
+COPY package-lock.json ./
+RUN npm install --silent
+COPY . ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.8'
 services:
   node:
+    image: $DOCKER_REGISTRY_URL
     build:
       context: .
     env_file: ./.env
@@ -9,9 +10,6 @@ services:
     command: npm start
     links:
       - db
-    volumes:
-      - .:/app/
-      - /app/node_modules
   db:
     image: postgres:14.4-alpine
     restart: always


### PR DESCRIPTION
By configuring `DOCKER_REGISTRY_URL` and then running `docker-compose build` and `docker-compose push`, you can then use the docker-compose.yml recipe on remote hosting services or host on your own home server using Unraid and Docker Compose Manager.