### PR TITLE
update url regex match

### DIFF
--- a/common/utils.js
+++ b/common/utils.js
@@ -40,6 +40,6 @@ module.exports = {
     },
     checkUrl(string) {
     	// regex credit: https://stackoverflow.com/a/17773849
-    	return string.match(/([0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.[^\s]{2,})/)
+    	return string.match(/([0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.[^\s]{2,}|www\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\.[^\s]{2,})/)
     }
 }

--- a/common/utils.js
+++ b/common/utils.js
@@ -40,6 +40,6 @@ module.exports = {
     },
     checkUrl(string) {
     	// regex credit: https://stackoverflow.com/a/17773849
-    	return string.match(/([0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]+\.[^\s]{2,}|www\.[a-zA-Z0-9]+\.[^\s]{2,})/)
+    	return string.match(/([0-9][a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]*\.[^\s]{2,})/)
     }
 }


### PR DESCRIPTION
**Fix URL regex to match domains with hyphens**

**Problem**
The current URL regex was failing to match valid URLs containing hyphens in the domain name. Specifically, URLs like https://mydomain-hyphenated.com/form-fox-hooks were not being detected, while equivalent URLs without hyphens (like https://mydomainhyphenated.com/form-fox-hooks) worked correctly.

**Root Cause**
The regex pattern `[a-zA-Z0-9]+` in the HTTPS and www sections only allowed alphanumeric characters, excluding hyphens which are valid in domain names according to RFC standards.

**Solution**
Updated the regex pattern from:
`[a-zA-Z0-9]+`
to:
`[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?`

**This change:**

- Ensures domains start with an alphanumeric character
- Allows hyphens in the middle of domain names
- Prevents domains from ending with hyphens
- Maintains RFC compliance for valid domain names